### PR TITLE
Added support for symbol endpoint

### DIFF
--- a/spec/symbols.spec.ts
+++ b/spec/symbols.spec.ts
@@ -4,7 +4,7 @@ const fixer = require('../dist');
 
 const accessKey = process.env.FIXER_API_KEY;
 
-describe('#latest', () => {
+describe('#symbols', () => {
   describe('default fixer', () => {
     it('should get symbol data', async () => {
       const result = await fixer.symbols({

--- a/spec/symbols.spec.ts
+++ b/spec/symbols.spec.ts
@@ -1,0 +1,24 @@
+import 'jest';
+
+const fixer = require('../dist');
+
+const accessKey = process.env.FIXER_API_KEY;
+
+describe('#latest', () => {
+  describe('default fixer', () => {
+    it('should get symbol data', async () => {
+      const result = await fixer.symbols({
+        access_key: accessKey
+      });
+
+      expect(result).toMatchObject({
+        symbols: expect.objectContaining({
+          AED: 'United Arab Emirates Dirham',
+          AFN: 'Afghan Afghani',
+          ALL: 'Albanian Lek'
+        }),
+        success: true
+      });
+    });
+  });
+});

--- a/src/Fixer.ts
+++ b/src/Fixer.ts
@@ -1,6 +1,11 @@
 import { DEFAULT_URL } from './constants';
 import formatDate from './formatDate';
 
+export interface IFixerError {
+  readonly type: string;
+  readonly info: string;
+}
+
 export interface IFixerRates {
   readonly [currency: string]: number;
 }
@@ -10,10 +15,16 @@ export interface IFixerResponse {
   readonly date: string;
   readonly rates: IFixerRates;
   readonly timestamp: number;
-  readonly error?: {
-    type: string,
-    info: string
-  };
+  readonly error?: IFixerError;
+}
+
+export interface IFixerSymbols {
+  readonly [symbol: string]: string;
+}
+
+export interface IFixerSymbolResponse {
+  readonly symbols: IFixerSymbols;
+  readonly error?: IFixerError;
 }
 
 export interface IFixerConvertRequestOptions {
@@ -81,6 +92,10 @@ export abstract class Fixer {
 
   async latest(opts: Partial<IRequestOptions> = {}): Promise<IFixerResponse> {
     return this.request<IFixerResponse>('/latest', opts);
+  }
+
+  async symbols(opts: Partial<IRequestOptions> = {}): Promise<IFixerSymbolResponse> {
+    return this.request<IFixerSymbolResponse>('/symbols', opts);
   }
 
   async convert(from: string, to: string, amount: number, date?: Date | string):

--- a/src/NodeFixer.spec.ts
+++ b/src/NodeFixer.spec.ts
@@ -214,6 +214,28 @@ describe('NodeFixer', () => {
     })).rejects.toThrow('Invalid date argument');
   });
 
+  it('fetches symbols', async () => {
+    const mockResponse = {
+      success: true,
+      symbols: {
+        AED: 'United Arab Emirates Dirham',
+      }
+    };
+
+    setMockedResponse(mockResponse);
+
+    const result = await fixer.symbols({
+      access_key: '123456',
+    });
+
+    expect(mockedFetch)
+        .toBeCalledWith(
+            'http://data.fixer.io/api/symbols?access_key=123456'
+        );
+
+    expect(result).toEqual(mockResponse);
+  });
+
   it('gets initialized with custom options', async () => {
     const newFixer = new NodeFixer(nodeFetch, { baseUrl: 'any' });
     setMockedResponse(null);


### PR DESCRIPTION
Hey Sergey - I needed the [symbols](https://fixer.io/documentation#supportedsymbols) endpoint for some work I'm doing and thought it might be useful to others. Feel free to disregard if you're not interested in adding support for that endpoint to the library. Equally, I'm happy to action any feedback.

Thanks for your work!