### PR TITLE
chore(security): bump node-fetch to 2.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3354,9 +3354,33 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "4.5.4"
   },
   "dependencies": {
-    "node-fetch": "^2.6.1"
+    "node-fetch": "2.6.7"
   },
   "homepage": "https://github.com/svlapin/fixer-api#readme",
   "engines": {


### PR DESCRIPTION
`node-fetch` is vulnerable to information (security headers) exposure under some conditions.
Snyk suggests updating to 3.1.1, but it contains [breaking changes](https://github.com/node-fetch/node-fetch/blob/main/docs/v3-UPGRADE-GUIDE.md) (e.g. requirement of ESM modules) which might not be desirable by end users of this package.

2.6.7, however, [has the patch backported](https://github.com/node-fetch/node-fetch/releases/tag/v2.6.7).


https://security.snyk.io/vuln/SNYK-JS-NODEFETCH-2342118